### PR TITLE
Custom mouse buttons for menu item clicks

### DIFF
--- a/zoo/libs/pyqt/extended/menu.py
+++ b/zoo/libs/pyqt/extended/menu.py
@@ -1,0 +1,16 @@
+from qt import QtWidgets, QtCore
+
+
+class Menu(QtWidgets.QMenu):
+    mouseButtonClicked = QtCore.Signal(object, object)  # emits (mouseButton, QAction)
+
+    def mouseReleaseEvent(self, event):
+        """ Emit signal for other mouse events like middle and right click for Menu Items
+
+        :param event:
+        :type event: QtGui.QMouseEvent
+        :return:
+        """
+        self.mouseButtonClicked.emit(event.button(), self.actionAt(event.pos()))
+
+        return super(Menu, self).mouseReleaseEvent(event)

--- a/zoo/libs/pyqt/extended/searchablemenu/menu.py
+++ b/zoo/libs/pyqt/extended/searchablemenu/menu.py
@@ -13,18 +13,21 @@
     men.exec_(QtGui.QCursor.pos())
 
 """
-from qt import QtWidgets
+from qt import QtWidgets, QtGui, QtCore
 
+from zoo.libs.pyqt.extended import menu
 from zoo.libs.pyqt.extended.searchablemenu import action as taggedAction
 from zoo.libs.pyqt import utils
 
 __all__ = ("SearchableMenu",)
 
 
-class SearchableMenu(QtWidgets.QMenu):
-    """Extended the standard QMenu to make it searchable, first action is always a lineedit used to
+class SearchableMenu(menu.Menu):
+    """ Extended the standard QMenu to make it searchable, first action is always a lineedit used to
     recursively search all sub actions by tags
     """
+
+    mouseButtonClicked = QtCore.Signal(object)
 
     def __init__(self, **kwargs):
         """

--- a/zoo/libs/pyqt/extended/searchwidget.py
+++ b/zoo/libs/pyqt/extended/searchwidget.py
@@ -7,8 +7,14 @@ class SearchLineEdit(QtWidgets.QLineEdit):
     """
     textCleared = QtCore.Signal()
 
-    def __init__(self, searchPixmap, clearPixmap, parent=None):
+    def __init__(self, searchPixmap=None, clearPixmap=None, parent=None):
         QtWidgets.QLineEdit.__init__(self, parent)
+
+        if searchPixmap is None:
+            searchPixmap = iconlib.iconColorized("magnifier", 16, (128,128,128))  # these should be in layouts
+
+        if clearPixmap is None:
+            clearPixmap = iconlib.iconColorized("close", 16, (128,128,128))
 
         self.clearButton = QtWidgets.QToolButton(self)
         self.clearButton.setIcon(QtGui.QIcon(clearPixmap))
@@ -19,7 +25,7 @@ class SearchLineEdit(QtWidgets.QLineEdit):
         self.textChanged.connect(self.updateCloseButton)
 
         self.searchButton = QtWidgets.QToolButton(self)
-        self.searchButton.setStyleSheet("QToolButton { border: none; padding: 0px; }")
+        self.searchButton.setStyleSheet("QToolButton { border: none; padding: 1px; }")
         self.searchButton.setIcon(QtGui.QIcon(searchPixmap))
 
         frameWidth = self.style().pixelMetric(QtWidgets.QStyle.PM_DefaultFrameWidth)

--- a/zoo/libs/pyqt/widgets/extendedbutton.py
+++ b/zoo/libs/pyqt/widgets/extendedbutton.py
@@ -1,8 +1,9 @@
-from qt import QtWidgets, QtCore, QtGui
+from qt import QtWidgets, QtCore
 
 from zoo.libs import iconlib
 from zoo.libs.pyqt import utils
 from zoo.libs.pyqt.extended import searchablemenu
+from zoo.libs.pyqt.extended.menu import Menu
 from zoo.libs.pyqt.extended.searchablemenu import action as taggedAction
 from zoo.libs.utils import zlogging, colour
 
@@ -393,7 +394,7 @@ class ExtendedButton(QtWidgets.QPushButton, ButtonIcons):
                 self.clickMenu[mouseMenu] = searchablemenu.SearchableMenu(objectName="extendedButton",
                                                                           title="Extended Button")
             else:
-                self.clickMenu[mouseMenu] = QtWidgets.QMenu()
+                self.clickMenu[mouseMenu] = Menu()
 
         return self.clickMenu[mouseMenu]
 
@@ -405,6 +406,8 @@ class ExtendedButton(QtWidgets.QPushButton, ButtonIcons):
         :param connect: The function to connect when the menu item is pressed
         :param checkable: If the menu item is checkable
         :return:
+        :rtype: taggedAction.TaggedAction
+
         """
         menu = self.getMenu(mouseMenu, searchable=self.isSearchable(mouseMenu))
 


### PR DESCRIPTION
Added mouseButtonClicked signal that emits a signal of the button pressed and the action clicked. This allows for Middle mouse and right mouse for menu item actions. This is applied for SearchableMenu and the ExtendedButtons menu.

Also added search widget default icons for convenience.