### PR TITLE
Round button stylesheet can be set

### DIFF
--- a/zoo/libs/pyqt/widgets/floatingbutton.py
+++ b/zoo/libs/pyqt/widgets/floatingbutton.py
@@ -74,10 +74,10 @@ class FloatingButton(dialog.Dialog):
         h = self.rect().height()
 
         if self.alignment == QtCore.Qt.AlignTop:
-            super(FloatingButton, self).move(x+(w/2), y)
+            super(FloatingButton, self).move(x+(w*0.5), y)
         elif self.alignment == QtCore.Qt.AlignRight:
-            super(FloatingButton, self).move(x-w, y-(h/2))
+            super(FloatingButton, self).move(x-w, y-(h*0.5))
         elif self.alignment == QtCore.Qt.AlignBottom:
             super(FloatingButton, self).move(x, y-h)
         elif self.alignment == QtCore.Qt.AlignLeft:
-            super(FloatingButton, self).move(x, y-(h/2))
+            super(FloatingButton, self).move(x, y-(h*0.5))

--- a/zoo/libs/pyqt/widgets/roundbutton.py
+++ b/zoo/libs/pyqt/widgets/roundbutton.py
@@ -34,6 +34,8 @@ class RoundButton(QtWidgets.QPushButton):
     def __init__(self, parent=None, text=None, icon=None, method=METHOD_STYLESHEET):
         super(RoundButton, self).__init__(parent=parent,text=text, icon=icon)
         self.method = method
+        self.customStyle = ""
+        self.updateButton()
 
     def setMethod(self, method=METHOD_MASK):
         """Set the method of rendering, Method.Mask or Method.StyleSheet
@@ -51,6 +53,7 @@ class RoundButton(QtWidgets.QPushButton):
         :return:
         """
         self.method = method
+        self.updateButton()
 
     def resizeEvent(self, event):
         """Resize and update based on the method
@@ -58,11 +61,37 @@ class RoundButton(QtWidgets.QPushButton):
         :return:
         """
 
+        self.updateButton()
+        super(RoundButton, self).resizeEvent(event)
+
+    def updateButton(self):
         if self.method == METHOD_MASK:
             self.setMask(QtGui.QRegion(self.rect(), QtGui.QRegion.Ellipse))
         elif self.method == METHOD_STYLESHEET:
-            radius = min(self.rect().width()*0.5, self.rect().width()*0.5)
-            self.setStyleSheet("border-radius: {}px;".format(radius))
+            super(RoundButton, self).setStyleSheet(self.roundStyle() + self.customStyle)
 
-        super(RoundButton, self).resizeEvent(event)
+    def roundStyle(self):
+        """ Style for round button
+
+        :return:
+        """
+        radius = min(self.rect().width() * 0.5, self.rect().width() * 0.5)
+        return "border-radius: {}px;".format(radius)
+
+    def setStyleSheet(self, text):
+        """ Set stylesheet for button
+
+        :param text:
+        :return:
+        """
+
+        # Do something different for the stylesheet type button
+        if self.method == METHOD_STYLESHEET:
+            self.customStyle = text
+            self.updateButton()
+        else:
+            super(RoundButton, self).setStyleSheet(text)
+
+
+
 


### PR DESCRIPTION
Previously setting the stylesheet would break the rounded corners, should be able to add these in now just using the normal stylesheet functions.

Also change divide to multiply in floatingbutton.