### PR TITLE
Widgets pro move

### DIFF
--- a/zoo/libs/pyqt/extended/viewfilterwidget.py
+++ b/zoo/libs/pyqt/extended/viewfilterwidget.py
@@ -2,7 +2,8 @@ from qt import QtCore, QtWidgets
 
 from zoo.libs import iconlib
 from zoo.libs.pyqt import utils
-from zoo.libs.pyqt.extended import combobox, searchwidget
+from zoo.libs.pyqt.extended import combobox
+from zoo.libs.pyqt.widgets import searchwidget
 
 
 class ViewSearchWidget(QtWidgets.QWidget):

--- a/zoo/libs/pyqt/widgets/flowlayout.py
+++ b/zoo/libs/pyqt/widgets/flowlayout.py
@@ -1,0 +1,252 @@
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+FlowLayout
+Custom layout that mimics the behaviour of a flow layout (not supported in PyQt by default)
+@source https://qt.gitorious.org/pyside/pyside-examples/source/060dca8e4b82f301dfb33a7182767eaf8ad3d024:examples/layouts/flowlayout.py
+Comments added by Jos Balcaen(http://josbalcaen.com/)
+@date 1/1/2015
+
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+from qt import QtWidgets, QtCore
+import shiboken2
+
+from zoo.libs.pyqt import utils
+
+
+class FlowLayout(QtWidgets.QLayout):
+    """Custom layout that mimics the behaviour of a flow layout"""
+
+    def __init__(self, parent=None, margin=0, spacingX=2, spacingY=2):
+        """ Create a new FlowLayout instance.
+
+        This layout will reorder the items automatically.
+
+        :param parent (QWidget)
+        :param margin (int)
+        :param spacing (int)
+        """
+        super(FlowLayout, self).__init__(parent)
+        # Set margin and spacing
+        if parent is not None:
+            self.setMargin(margin)
+
+        self.spacingX = 0
+        self.spacingY = 0
+        self._orientation = QtCore.Qt.Horizontal
+        self.setSpacing(spacingX)
+        self.setSpacingX(spacingX)
+        self.setSpacingY(spacingY)
+        self.itemList = []
+        self.overflow = None
+
+        self.sizeHintLayout = self.minimumSize()
+
+    def __del__(self):
+        """Delete all the items in this layout"""
+        self.clear()
+
+    def orientation(self):
+        return self._orientation
+
+    def setOrientation(self, orientation):
+        """ Set out how the widgets will be laid out. Horizontally or vertically
+
+        :param orientation: Orientation of the widgets
+        :type orientation: QtCore.Qt.Horizontal or QtCore.Qt.Horizontal
+        :return:
+        """
+        self._orientation = orientation
+
+    def clear(self):
+        """
+        Clear all widgets
+        :return:
+        """
+        item = self.takeAt(0)
+        while item:
+            widget = item.widget()
+            if widget is not None:
+                widget.deleteLater()
+
+            item = self.takeAt(0)
+
+    def addItem(self, item):
+        """Add an item at the end of the layout.
+        This is automatically called when you do addWidget()
+
+        :param item:
+        :type item: QWidgetItem
+        """
+        self.itemList.append(item)
+
+    def addSpacing(self, spacing):
+        spaceWgt = QtWidgets.QWidget()
+        spaceWgt.setFixedSize(QtCore.QSize(spacing, spacing))
+        self.addWidget(spaceWgt)
+
+    def count(self):
+        """Get the number of items in the this layout
+
+        :return (int)"""
+        return len(self.itemList)
+
+    def itemAt(self, index):
+        """Get the item at the given index
+
+        :param index (int)
+        :return (QWidgetItem)"""
+        if 0 <= index < len(self.itemList):
+            return self.itemList[index]
+        return None
+
+    def takeAt(self, index):
+        """Remove an item at the given index
+
+        :param index (int)
+        :return (None)"""
+        if 0 <= index < len(self.itemList):
+            return self.itemList.pop(index)
+        return None
+
+    def insertWidget(self, index, widget):
+        """Insert a widget at a given index
+
+        :param index (int)
+        :param widget (QWidget)"""
+        item = QtWidgets.QWidgetItem(widget)
+        self.itemList.insert(index, item)
+
+    def items(self):
+        remove = []
+        for item in self.itemList:
+            if not shiboken2.isValid(item):
+                remove.append(item)
+
+        [self.itemList.remove(r) for r in remove]
+        return self.itemList
+
+    def expandingDirections(self):
+        """ This layout grows only in the horizontal dimension or vertical direction
+        depending on current orientation """
+
+        return QtCore.Qt.Orientations(self.orientation())
+
+    def hasHeightForWidth(self):
+        """If this layout's preferred height depends on its width
+
+        :return (boolean) Always True """
+
+        return self.orientation() == QtCore.Qt.Horizontal
+
+    def heightForWidth(self, width):
+        """Get the preferred height a layout item with the given width
+
+        :param width (int)"""
+
+        height = self.doLayout(QtCore.QRect(0, 0, width, 0), True)
+
+        self.sizeHintLayout = QtCore.QSize(width, height)
+
+        return height
+
+    def setGeometry(self, rect):
+        """Set the geometry of this layout
+
+        :param rect (QRect)"""
+        super(FlowLayout, self).setGeometry(rect)
+        self.doLayout(rect, False)
+
+    def allowOverflow(self, allow):
+        """ Allows the flow layouts to overflow, rather than go onto the next line
+
+        :param allow: True to allow, False to not allow
+        :type allow: bool
+        :return:
+        """
+        self.overflow = allow
+
+    def sizeHint(self):
+        """ Get the preferred size of this layout
+
+        :return (QSize) The minimum size"""
+        return self.sizeHintLayout
+
+    def minimumSize(self):
+        """ Get the minimum size of this layout
+
+        :return (QSize)"""
+        # Calculate the size
+        size = QtCore.QSize()
+        for item in self.itemList:
+            size = size.expandedTo(item.minimumSize())
+        # Add the margins
+        size += QtCore.QSize(2, 2)
+        return size
+
+    def setSpacingX(self, spacing):
+        """X Spacing for each item
+
+        :param spacing:
+        :return:
+        """
+        self.spacingX = utils.dpiScale(spacing)
+
+    def setSpacingY(self, spacing):
+        """ Y Spacing for each item
+
+        :param spacing:
+        :return:
+        """
+        self.spacingY = utils.dpiScale(spacing)
+
+    def doLayout(self, rect, testOnly):
+        """ Layout all the items
+
+        :param rect (QRect) Rect where in the items have to be laid out
+        :param testOnly (boolean) Do the actual layout"""
+
+        x = rect.x()
+        y = rect.y()
+        lineSize = 0
+        orientation = self.orientation()
+
+        for item in self.itemList:
+
+            if item.widget().isHidden():
+                continue
+
+            spaceX = self.spacingX
+            spaceY = self.spacingY
+
+            if orientation == QtCore.Qt.Horizontal:
+                nextX = x + item.sizeHint().width() + spaceX
+                if nextX - spaceX > rect.right() and lineSize > 0:
+                    if not self.overflow:
+                        x = rect.x()
+                        y = y + lineSize + (spaceY * 2)
+                        nextX = x + item.sizeHint().width() + spaceX
+                        lineSize = 0
+
+                if not testOnly:
+                    item.setGeometry(
+                            QtCore.QRect(QtCore.QPoint(x, y), item.sizeHint()))
+                x = nextX
+                lineSize = max(lineSize, item.sizeHint().height())
+            else:
+                nextY = y + item.sizeHint().height() + spaceY
+                if nextY - spaceY > rect.bottom() and lineSize > 0:
+                    if not self.overflow:
+                        y = rect.y()
+                        x = x + lineSize + (spaceX * 2)
+                        nextY = y + item.sizeHint().height() + spaceY
+                        lineSize = 0
+
+                if not testOnly:
+                    item.setGeometry(
+                        QtCore.QRect(QtCore.QPoint(x, y), item.sizeHint()))
+                x = nextY
+                lineSize = max(lineSize, item.sizeHint().height())
+
+        if orientation == QtCore.Qt.Horizontal:
+            return y + lineSize - rect.y()
+        else:
+            return x + lineSize - rect.x()

--- a/zoo/libs/pyqt/widgets/layouts.py
+++ b/zoo/libs/pyqt/widgets/layouts.py
@@ -5,7 +5,7 @@ from qt import QtWidgets, QtCore, QtGui
 from zoo.libs import iconlib
 from zoo.libs.pyqt import uiconstants, utils
 from zoo.libs.pyqt.extended import combobox
-from zoo.libs.pyqt.widgets import frame, extendedbutton
+from zoo.libs.pyqt.widgets import frame
 
 
 def Label(name, parent, toolTip="", upper=False):
@@ -101,85 +101,6 @@ def LineEdit(text="", placeholder="", parent=None, toolTip="", editWidth=None, i
     textBox.setText(str(text))
     textBox.setToolTip(toolTip)
     return textBox
-
-
-class StringEdit(QtWidgets.QWidget):
-    textChanged = QtCore.Signal(str)
-    buttonClicked = QtCore.Signal()
-    editingFinished = QtCore.Signal()
-
-    def __init__(self, label="", editText="", editPlaceholder="", buttonText=None, parent=None, editWidth=None,
-                 labelRatio=1, btnRatio=1, editRatio=1, toolTip="", inputMode="string",
-                 orientation=QtCore.Qt.Horizontal):
-        """Creates a label, textbox (QLineEdit) and an optional button
-        if the button is None then no button will be created
-
-        :param label: the label name
-        :type label: str
-        :param placeholderText: default text is greyed out inside the textbox if true (QLineEdit)
-        :type placeholderText: bool
-        :param buttonText: optional button name, if None no button will be created
-        :type buttonText: str
-        :param parent: the qt parent
-        :type parent: class
-        :param editWidth: the width of the textbox in pixels optional, None is ignored
-        :type editWidth: int
-        :param labelRatio: the width ratio of the label/text/button corresponds to the ratios of ratioEdit/ratioBtn
-        :type labelRatio: int
-        :param btnRatio: the width ratio of the label/text/button corresponds to the ratios of editRatio/labelRatio
-        :type btnRatio: int
-        :param editRatio: the width ratio of the label/text/button corresponds to the ratios of labelRatio/btnRatio
-        :type editRatio: int
-        :param toolTip: the tool tip message on mouse over hover, extra info
-        :type toolTip: str
-        :param inputMode: restrict the user to this data entry, "string" text, "float" decimal or "int" no decimal
-        :type inputMode: str
-        :param orientation: the orientation of the box layout QtCore.Qt.Horizontal HBox QtCore.Qt.Vertical VBox
-        :type orientation: bool
-        :return StringEdit: returns the class with various options, see the methods
-        :rtype StringEdit: QWidget
-        """
-        super(StringEdit, self).__init__(parent=parent)
-        self.QLineEditBool = True
-        if orientation == QtCore.Qt.Horizontal:
-            self.layout = HBoxLayout(parent, (0, 0, 0, 0), spacing=uiconstants.SREG)
-        else:
-            self.layout = VBoxLayout(parent, (0, 0, 0, 0), spacing=uiconstants.SREG)
-        self.edit = LineEdit(editText, editPlaceholder, parent, toolTip, editWidth, inputMode)
-        if label:
-            self.label = Label(label, parent, toolTip)
-            self.layout.addWidget(self.label, labelRatio)
-        self.layout.addWidget(self.edit, editRatio)
-        self.buttonText = buttonText
-        if self.buttonText:
-            # todo button connections should be added from this class (connections)
-            self.btn = extendedbutton.buttonStyle(self.buttonText, toolTip=toolTip, style=uiconstants.BTN_DEFAULT)
-            self.layout.addWidget(self.btn, btnRatio)
-        self.setLayout(self.layout)
-        self.connections()
-
-    def connections(self):
-        """connects the buttons and text changed emit"""
-        self.edit.textChanged.connect(self._onTextChanged)
-        if self.buttonText:
-            self.btn.clicked.connect(self.buttonClicked.emit)
-        self.editingFinished = self.edit.editingFinished
-
-    def _onTextChanged(self):
-        """If the text is changed emit"""
-        self.textChanged.emit(str(self.edit.text()))
-
-    def setDisabled(self, state):
-        """Disable the text (make it grey)"""
-        self.edit.setDisabled(state)
-
-    def setText(self, value):
-        """Change the text at any time"""
-        self.edit.setText(value)
-
-    def text(self):
-        """get the text of self.edit"""
-        return self.edit.text()
 
 
 class ComboBoxSearchable(QtWidgets.QWidget):

--- a/zoo/libs/pyqt/widgets/searchwidget.py
+++ b/zoo/libs/pyqt/widgets/searchwidget.py
@@ -1,0 +1,66 @@
+from qt import QtCore, QtGui, QtWidgets
+from zoo.libs import iconlib
+from zoo.libs.pyqt import utils
+
+
+class SearchLineEdit(QtWidgets.QLineEdit):
+    """Search Widget with two icons one on either side, inherits from QLineEdit
+    """
+    textCleared = QtCore.Signal()
+
+    def __init__(self, searchPixmap=None, clearPixmap=None, parent=None):
+        QtWidgets.QLineEdit.__init__(self, parent)
+
+        if searchPixmap is None:
+            searchPixmap = iconlib.iconColorized("magnifier", utils.dpiScale(16), (128,128,128))  # these should be in layouts
+
+        if clearPixmap is None:
+            clearPixmap = iconlib.iconColorized("close", utils.dpiScale(16), (128,128,128))
+
+        self.clearButton = QtWidgets.QToolButton(self)
+        self.clearButton.setIcon(QtGui.QIcon(clearPixmap))
+        self.clearButton.setCursor(QtCore.Qt.ArrowCursor)
+        self.clearButton.setStyleSheet("QToolButton { border: none; padding: 1px; }")
+        self.clearButton.hide()
+        self.clearButton.clicked.connect(self.clear)
+        self.textChanged.connect(self.updateCloseButton)
+
+        self.searchButton = QtWidgets.QToolButton(self)
+        self.searchButton.setStyleSheet("QToolButton { border: none; padding: 0px; }")
+        self.searchButton.setIcon(QtGui.QIcon(searchPixmap))
+
+        frameWidth = self.style().pixelMetric(QtWidgets.QStyle.PM_DefaultFrameWidth)
+        self.setStyleSheet("QLineEdit { padding-left: %dpx; padding-right: %dpx; } "%(
+            self.searchButton.sizeHint().width() + frameWidth + 1,
+            self.clearButton.sizeHint().width() + frameWidth + 1))
+
+        msz = self.minimumSizeHint()
+        self.setMinimumSize(max(msz.width(),
+                                self.searchButton.sizeHint().width() +
+                                self.clearButton.sizeHint().width() + frameWidth * 2 + 2),
+                            max(msz.height(),
+                                self.clearButton.sizeHint().height() + frameWidth * 2 + 2))
+
+
+    def resizeEvent(self, event):
+        sz = self.clearButton.sizeHint()
+        frameWidth = self.style().pixelMetric(QtWidgets.QStyle.PM_DefaultFrameWidth)
+        rect = self.rect()
+        yPos = (rect.bottom() + 1 - sz.height()) * 0.5
+        self.clearButton.move(self.rect().right() - frameWidth - sz.width(), yPos)
+        self.searchButton.move(self.rect().left() + 1, yPos)
+
+    def updateCloseButton(self, text):
+        if text:
+            self.clearButton.setVisible(True)
+            return
+        self.clearButton.setVisible(False)
+
+
+if __name__ == "__name__":
+    app = QtWidgets.QApplication([])
+    searchIcon = QtGui.QPixmap(iconlib.icon("magnifier"), 16)
+    closeIcon = QtGui.QPixmap(iconlib.icon("code", 16))
+    w = SearchLineEdit(searchIcon, closeIcon)
+    w.show()
+    app.exec_()


### PR DESCRIPTION
Also removed some dependencies to zoocore_pro I found.

I moved FlowLayout and SearchWidget back to zoocore from zoocore_pro as some of the widgets needed it here.

Also moved StringEdit to zoocore_pro to avoid zoocore_pro dependencies (it uses extendedbutton). Let me know if this might cause problems with the core code, it's mostly used in the new stuff like toolsets, but it's also used in some of older ui code like the old hive ui and renamer ui. Let me know if you want any changes in this area.