### PR TITLE
Fixing reference to extended button in zoocore

### DIFF
--- a/zoo/libs/pyqt/uiconstants.py
+++ b/zoo/libs/pyqt/uiconstants.py
@@ -36,7 +36,7 @@ BTN_DEFAULT = 0  # Default zoo extended button with optional text or an icon.
 BTN_TRANSPARENT_BG = 1  # Default zoo extended button w transparent bg.
 BTN_ICON_SHADOW = 2  # Main zoo IconPushButton button (icon in a colored box) with shadow underline
 BTN_DEFAULT_QT = 3   # Default style uses vanilla QPushButton and not zoo's extended button
-BTN_ROUNDED = 4  # Rounded button stylesheeted bg color and stylesheeted icon color
+BTN_ROUNDED = 4  # Rounded button stylesheeted bg color and stylesheeted icon colour
 
 # Colors
 COLOR_ERROR = "00ff06"  # fluorescent green

--- a/zoo/libs/pyqt/widgets/layouts.py
+++ b/zoo/libs/pyqt/widgets/layouts.py
@@ -1218,7 +1218,7 @@ def InputDialog(windowName="Add Name", textValue="", parent="", message="Rename?
 
 class EmbeddedWindow(QtWidgets.QFrame):
 
-    def __init__(self, parent, title, defaultVisibility=True, uppercase=False):
+    def __init__(self, parent, title, defaultVisibility=True, uppercase=False, closeButton=None):
         """An embedded window is a QFrame widget that appears like a window inside of another ui.
 
         It is not a window itself, more like a fake window.  It has some simple stylesheeting and a title
@@ -1236,14 +1236,21 @@ class EmbeddedWindow(QtWidgets.QFrame):
         :type title: str
         :param defaultVisibility: Is the embedded window visible on initialize?
         :type defaultVisibility: bool
+        :param closeButton: the button (object) used to close the window
+        :type closeButton: qt object
         """
         super(EmbeddedWindow, self).__init__(parent)
         self.title = title
         self.parent = parent
         self.uppercase = uppercase
+        if closeButton:
+            self.hidePropertiesBtn = closeButton
+        else:
+            self.hidePropertiesBtn = None
         self.setHidden(defaultVisibility)
         self.ui()
         self.connections()
+
 
     def ui(self):
         """Create the UI with a title and close icon top right
@@ -1260,12 +1267,10 @@ class EmbeddedWindow(QtWidgets.QFrame):
         # Title Of the Embedded Window
         propertyTitleLayout = HBoxLayout(self.parent, margins=(0, 0, 0, 0), spacing=uic.SSML)
         self.propertiesLbl = Label(self.title, self.parent, upper=self.uppercase, bold=True)
-        toolTip = "Close this embedded window"
-        self.hidePropertiesBtn = extendedbutton.buttonStyle("", "closeX", self.parent, toolTip,
-                                                            maxWidth=uic.BTN_W_ICN_SML, minWidth=uic.BTN_W_ICN_SML,
-                                                            style=uic.BTN_TRANSPARENT_BG)
+
         propertyTitleLayout.addWidget(self.propertiesLbl, 10)
-        propertyTitleLayout.addWidget(self.hidePropertiesBtn, 1)
+        if self.hidePropertiesBtn:
+            propertyTitleLayout.addWidget(self.hidePropertiesBtn, 1)
 
         self.propertiesLayout.addLayout(propertyTitleLayout)
 
@@ -1282,7 +1287,8 @@ class EmbeddedWindow(QtWidgets.QFrame):
     def getHideButton(self):
         """Returns the hide button so functionality can be assigned to it
         """
-        return self.hidePropertiesBtn
+        if self.hidePropertiesBtn:
+            return self.hidePropertiesBtn
 
     def setTitle(self, title):
         """Set the title of the embedded window


### PR DESCRIPTION
EmbededWindow now has it's close button passed in as an object to work around importing from zoocore_pro